### PR TITLE
Move npm install to build script

### DIFF
--- a/nodejs-with-nosql/todo/scripts/boot.sh
+++ b/nodejs-with-nosql/todo/scripts/boot.sh
@@ -16,6 +16,3 @@ sed -i -e "s/process.env.DATABASE_PORT/\"${DATABASE_PORT}\"/" "${database_conf_f
 sed -i -e "s/process.env.DATABASE_USER/\"${DATABASE_USER}\"/" "${database_conf_file}"
 sed -i -e "s/process.env.DATABASE_NAME/\"${DATABASE_NAME}\"/" "${database_conf_file}"
 sed -i -e "s/process.env.DATABASE_PASSWORD/\"${DATABASE_PASSWORD}\"/" "${database_conf_file}"
-
-# Installing application dependencies
-exec su "${system_user}" -c "cd ${installdir} && npm install"

--- a/nodejs-with-nosql/todo/scripts/build.sh
+++ b/nodejs-with-nosql/todo/scripts/build.sh
@@ -16,3 +16,6 @@ tar xzf ${UPLOADS_DIR}/app.tar.gz -C /opt
 
 # Set permissions
 chown -R ${system_user}:${system_user} ${installdir}
+
+# Installing application dependencies
+exec su "${system_user}" -c "cd ${installdir} && npm install"


### PR DESCRIPTION
This moves the execution of `npm install` from the boot script to the build script, since that's the natural place for it.