### PR TITLE
Ignore ROOT webapp dir

### DIFF
--- a/java-tomcat/customerapp/customerapp-boot.sh
+++ b/java-tomcat/customerapp/customerapp-boot.sh
@@ -16,7 +16,7 @@ echo "OK"
 # Only perform the setup once
 if [ ! -f "${FIRSTBOOT_STAMP}" ] ; then
     # Jump to the webapp directory
-    basedir=$(find /var/lib/tomcat/webapps/ -mindepth 1 -maxdepth 1 -type d | head -n 1)
+    basedir=$(find /var/lib/tomcat/webapps/ -mindepth 1 -maxdepth 1 -not -name 'ROOT' -type d | head -n 1)
     cd "${basedir}"
 
     # Configure database settings


### PR DESCRIPTION
Now created to redirect to the app by default.

This will skip the ROOT.

This will fail if someone uploads the consumerapp.war
with the name ROOT.war