### PR TITLE
Include DATABASE_CONNECTION_OPTIONS if defined

### DIFF
--- a/nodejs-with-nosql/todo/scripts/boot.sh
+++ b/nodejs-with-nosql/todo/scripts/boot.sh
@@ -16,3 +16,6 @@ sed -i -e "s/process.env.DATABASE_PORT/\"${DATABASE_PORT}\"/" "${database_conf_f
 sed -i -e "s/process.env.DATABASE_USER/\"${DATABASE_USER}\"/" "${database_conf_file}"
 sed -i -e "s/process.env.DATABASE_NAME/\"${DATABASE_NAME}\"/" "${database_conf_file}"
 sed -i -e "s/process.env.DATABASE_PASSWORD/\"${DATABASE_PASSWORD}\"/" "${database_conf_file}"
+# On Azure the DATABASE_CONNECTION_OPTIONS specify ssl=true (as tls is
+# required), whereas on AWS we don't use tls for the mongo connection (yet).
+sed -i -e "s/process.env.DATABASE_CONNECTION_OPTIONS/\"${DATABASE_CONNECTION_OPTIONS:-}\"/" "${database_conf_file}"


### PR DESCRIPTION
When deploying on Azure, Stacksmith sends the `DATABASE_CONNECTION_OPTIONS=ssl=true` user data to the vm, as Azure requires ssl for the mongo connection. This change ensures that the application's database config is updated with this if it is set, or empty otherwise.