### PR TITLE
Add wait for successful db ping before running app

### DIFF
--- a/dotnet-core-with-mysql/todo/scripts/boot.sh
+++ b/dotnet-core-with-mysql/todo/scripts/boot.sh
@@ -8,6 +8,13 @@ sed -i \
     "s!\(DefaultConnection.*\)\"Server=.*\"!\\1\"Server=${DATABASE_HOST}\\;Database=${DATABASE_NAME}\\;Uid=${DATABASE_USER};Pwd=${DATABASE_PASSWORD}\\;\"!" \
     "${appdir}/appsettings.json"
 
+# Wait for database to start then...
+while ! mysqladmin ping -h"$DATABASE_HOST" -P"$DATABASE_PORT" -u"$DATABASE_USER" -p"$DATABASE_PASSWORD" --silent; do
+    echo "Waiting for database to become available"
+    sleep 2
+done
+echo "Database available, continuing with application configuration and deploy"
+
 mysql --ssl "-u${DATABASE_USER}" "-p${DATABASE_PASSWORD}" "-h${DATABASE_HOST}" "${DATABASE_NAME}" -e "SELECT 1+1;"
 if ! mysql --ssl "-u${DATABASE_USER}" "-p${DATABASE_PASSWORD}" "-h${DATABASE_HOST}" "${DATABASE_NAME}" -e "SELECT COUNT(*) FROM Items;" ; then
     mysql --ssl "-u${DATABASE_USER}" "-p${DATABASE_PASSWORD}" "-h${DATABASE_HOST}" "${DATABASE_NAME}" -B <"${appdir}/mysql-schema.sql"

--- a/generic-with-mysql/ghost/scripts/boot.sh
+++ b/generic-with-mysql/ghost/scripts/boot.sh
@@ -40,7 +40,13 @@ cat >"$CONF_FILE" <<EOF
 EOF
 chown "$NON_ROOT_USER":"$NON_ROOT_USER" "$CONF_FILE"
 
-# Init database    
+# Wait for database to start then...
+while ! mysqladmin ping -h"$DATABASE_HOST" -P"$DATABASE_PORT" -u"$DATABASE_USER" -p"$DATABASE_PASSWORD" --silent; do
+    echo "Waiting for database to become available"
+    sleep 2
+done
+echo "Database available, continuing with application configuration and deploy"
+
 cd "$APP_DIR"
 echo "=> Initializing database..."
 sudo -H -u "$NON_ROOT_USER" NODE_ENV=production ./node_modules/.bin/knex-migrator init

--- a/generic/minio/scripts/build.sh
+++ b/generic/minio/scripts/build.sh
@@ -2,6 +2,7 @@
 
 # Update all the packages in the system.
 yum -y update
+yum install -y sudo
 yum clean all
 
 # Install Caddy Server using the Personal license

--- a/java-tomcat/customerapp/build-managed-db.sh
+++ b/java-tomcat/customerapp/build-managed-db.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# This user build script is required only when using the example with
+# Stacksmith's Java Tomcat application with DB (self-managed). The Java Tomcat
+# application with DB (MySQL) template already installs the mysql client.
+yum install -y mariadb

--- a/java-tomcat/jasperreports/scripts/boot.sh
+++ b/java-tomcat/jasperreports/scripts/boot.sh
@@ -10,6 +10,13 @@ export JAVA_HOME="/usr/lib/jvm/jre"
 readonly BUILDOMATIC_DIR="$(cd ${UPLOADS_DIR}/**/buildomatic; pwd)"
 readonly CONF="${BUILDOMATIC_DIR}/default_master.properties"
 
+# Wait for database to start then...
+while ! /usr/pgsql-9.6/bin/pg_isready -h "$DATABASE_HOST" -U "$DATABASE_USER" -p "$DATABASE_PORT" -d "$DATABASE_NAME" --quiet; do
+    echo "Waiting for database to become available"
+    sleep 2
+done
+echo "Database available, continuing with application configuration and deploy"
+
 # Check if the script has been executed before
 readonly SCRIPT_PATH=$(cd "$(dirname $0)" && pwd)
 readonly EXECUTED_ONCE_STAMP="${SCRIPT_PATH}/.boot-completed-once"

--- a/nodejs-with-nosql/todo/scripts/run.sh
+++ b/nodejs-with-nosql/todo/scripts/run.sh
@@ -8,5 +8,13 @@ readonly installdir=/opt/app
 # The user that should run the app
 readonly system_user=bitnami
 
+# Wait for the database to be available
+while ! mongo "mongodb://$DATABASE_USER:$DATABASE_PASSWORD@$DATABASE_HOST:$DATABASE_PORT/$DATABASE_NAME?${DATABASE_CONNECTION_OPTIONS:-}" --eval '{ping: 1}' --quiet;
+do
+    echo "Waiting for database to become available"
+    sleep 2
+done
+echo "Database available, continuing to run application."
+
 # Typically this is used to start something on foreground
 exec su "${system_user}" -c "cd ${installdir} && npm start"


### PR DESCRIPTION
When running locally, the app fails to start if the db isn't ready. This ensures it waits for a successful (authenticated) connection before starting the app.